### PR TITLE
Fix for #194

### DIFF
--- a/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
+++ b/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
@@ -115,7 +115,7 @@
                                  Margin="3,3,0,0"
                                  Text="{Binding Path=TravelTime,
                                                 FallbackValue=0,
-                                                Mode=OneWayToSource,
+                                                Mode=Default,
                                                 UpdateSourceTrigger=PropertyChanged,
                                                 ValidatesOnExceptions=True}"
                                  Validation.ErrorTemplate="{StaticResource errorTemplate}">
@@ -144,7 +144,7 @@
                         <TextBox 
                                  Margin="3,3,0,0"
                                  Text="{Binding Path=TravelRate,
-                                                Mode=OneWayToSource,
+                                                Mode=Default,
                                                 FallbackValue=0,
                                                 UpdateSourceTrigger=PropertyChanged,
                                                 ValidatesOnExceptions=True}"


### PR DESCRIPTION
After circle graphic is created, the Rate and Time boxes are now cleared along with Center Point and Radius / Diameter text boxes.