### PR TITLE
Fixes #194

### DIFF
--- a/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
+++ b/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
@@ -115,7 +115,7 @@
                                  Margin="3,3,0,0"
                                  Text="{Binding Path=TravelTime,
                                                 FallbackValue=0,
-                                                Mode=OneWayToSource,
+                                                Mode=Default,
                                                 UpdateSourceTrigger=PropertyChanged,
                                                 ValidatesOnExceptions=True}"
                                  Validation.ErrorTemplate="{StaticResource errorTemplate}">
@@ -144,7 +144,7 @@
                         <TextBox 
                                  Margin="3,3,0,0"
                                  Text="{Binding Path=TravelRate,
-                                                Mode=OneWayToSource,
+                                                Mode=Default,
                                                 FallbackValue=0,
                                                 UpdateSourceTrigger=PropertyChanged,
                                                 ValidatesOnExceptions=True}"


### PR DESCRIPTION
The Time and Rate text boxes are now set to zero after each point is created.