### PR TITLE
Fixes 260

### DIFF
--- a/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
+++ b/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
@@ -347,6 +347,8 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 }
 
                 base.LineDistanceType = value;
+
+                UpdateFeedbackWithGeoCircle();
             }
         }
 


### PR DESCRIPTION
Updating the preview circle each time the distance unit is changed in the combobox ensures the correct distance is used for the circle and associated label when the circle is actually created.