### PR TITLE
Fix for #259 - interactive

### DIFF
--- a/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/RangeViewModel.cs
+++ b/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/RangeViewModel.cs
@@ -350,6 +350,10 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 Point2 = (construct as IPolyline).ToPoint;
                 this.AddGraphicToMap(construct as IGeometry);
                 maxDistance = Math.Max(Distance, maxDistance);
+
+                // Use negative Distance to get the location for the distance label
+                construct.ConstructGeodesicCircle(Point1, GetLinearUnit(), -Distance, esriCurveDensifyMethod.esriCurveDensifyByAngle, 0.45);
+                this.AddTextToMap(construct as IGeometry, String.Format("{0} {1}{2}", Math.Round(Distance, 2).ToString(), GetLinearUnit().Name, "s"));
             }
         }
 


### PR DESCRIPTION
This fix adds labels in interactive mode using almost identical code as used in non-interactive mode. The labels don't always look great as depending on the units used the number component of the label can have many digits, causing the label to wrap around the whole circle. However, perhaps this fix is sufficient for this release.

![image](https://cloud.githubusercontent.com/assets/24588999/21940736/9538c858-d9bd-11e6-91d4-7769863f561c.png)
