### PR TITLE
#233 - Invisible Circle Distance Calculator combo boxes in Dark Mode

### DIFF
--- a/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
+++ b/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
@@ -149,6 +149,11 @@
                                     CommandParameter="{Binding ElementName=mainControl,
                                                                Path=.}" />
                             </ComboBox.InputBindings>
+                            <ComboBox.ItemContainerStyle>
+                                <Style TargetType="ComboBoxItem">
+                                    <Setter Property="Foreground" Value="Black" />
+                                </Style>
+                            </ComboBox.ItemContainerStyle>
                         </ComboBox>
                         <TextBlock 
                                    Margin="3,3,0,0"
@@ -179,6 +184,11 @@
                                     CommandParameter="{Binding ElementName=mainControl,
                                                                Path=.}" />
                             </ComboBox.InputBindings>
+                            <ComboBox.ItemContainerStyle>
+                                <Style TargetType="ComboBoxItem">
+                                    <Setter Property="Foreground" Value="Black" />
+                                </Style>
+                            </ComboBox.ItemContainerStyle>
                         </ComboBox>
                     </StackPanel>
                 </Expander>


### PR DESCRIPTION
These should be the last invisible combo boxes in dark mode:

See:
#233 - https://github.com/Esri/distance-direction-addin-dotnet/issues/233#issuecomment-272510932 

I wasn't sure if this invisible one was a v.next/showstopper issue or not - so opened PR just in case, if not needed it can wait.