### PR TITLE
Final fix for #49 - Escape key fully working for Pro and ArcMap

### DIFF
--- a/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/MapPointTool.cs
+++ b/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/MapPointTool.cs
@@ -103,6 +103,20 @@ namespace ArcMapAddinDistanceAndDirection
             Mediator.NotifyColleagues(Constants.MOUSE_DOUBLE_CLICK, null);
         }
 
+        protected override bool OnDeactivate()
+        {
+            return true;   
+        }
+
+        // If the user presses Escape cancel the sketch
+        protected override void OnKeyDown(KeyEventArgs k)
+        {
+            if (k.KeyCode == Keys.Escape)
+            {
+                Mediator.NotifyColleagues(DistanceAndDirectionLibrary.Constants.KEYPRESS_ESCAPE, null);
+            }
+        }
+
     }
 
 }

--- a/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -83,6 +83,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
 
         internal bool HasPoint1 = false;
         internal bool HasPoint2 = false;
+        internal bool HasPoint3 = false;
         internal INewLineFeedback feedback = null;
         internal FeatureClassUtils fcUtils = new FeatureClassUtils();
         internal KMLUtils kmlUtils = new KMLUtils();
@@ -746,6 +747,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 ClearTempGraphics();
                 Point1 = point;
                 HasPoint1 = true;
+                
                 Point1Formatted = string.Empty;
 
                 var color = new RgbColorClass() { Green = 255 } as IColor;
@@ -768,6 +770,11 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             {
                 CreateMapElement();
                 ResetPoints();
+            }
+
+            if (!HasPoint3)
+            {
+                HasPoint3 = true;
             }
         }
 
@@ -901,7 +908,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
         /// </summary>
         internal virtual void ResetPoints()
         {
-            HasPoint1 = HasPoint2 = false;
+            HasPoint1 = HasPoint2 = HasPoint3 = false;
         }
 
         /// <summary>
@@ -950,7 +957,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                         // User has activated the Map Point tool but not created a point
                         // Or User has previously finished creating a graphic
                         // Either way, assume they want to disable the Map Point tool
-                        if ((IsToolActive && !HasPoint1) || (IsToolActive && HasPoint2))
+                        if ((IsToolActive && !HasPoint1) || (IsToolActive && HasPoint3))
                         {
                             Reset(true);
                             IsToolActive = false;
@@ -960,7 +967,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                         // User has activated Map Point tool and created a point but not completed the graphic
                         // Assume they want to cancel any graphic creation in progress 
                         // but still keep the Map Point tool active
-                        if (IsToolActive && HasPoint1 && !HasPoint2)
+                        if (IsToolActive && HasPoint1 && !HasPoint3)
                         {
                             Reset(false);
                             return;

--- a/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -63,6 +63,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             Mediator.Register(Constants.NEW_MAP_POINT, OnNewMapPointEvent);
             Mediator.Register(Constants.MOUSE_MOVE_POINT, OnMouseMoveEvent);
             Mediator.Register(Constants.TAB_ITEM_SELECTED, OnTabItemSelected);
+            Mediator.Register(Constants.KEYPRESS_ESCAPE, OnKeypressEscape);
 
             configObserver = new PropertyObserver<DistanceAndDirectionConfig>(DistanceAndDirectionConfig.AddInConfig)
             .RegisterHandler(n => n.DisplayCoordinateType, n =>
@@ -931,6 +932,65 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
 
             IsActiveTab = (obj == this);
         }
+
+        /// <summary>
+        /// Handler for the escape key press event
+        /// Helps cancel operation when escape key is pressed
+        /// </summary>
+        /// <param name="obj">always null</param>
+        private void OnKeypressEscape(object obj)
+        {
+            if (isActiveTab)
+            {
+                if (ArcMap.Application.CurrentTool != null)
+                {
+                    // Special handling required for ellipses
+                    if (this is EllipseViewModel)
+                    {   
+                        // User has activated the Map Point tool but not created a point
+                        // Or User has previously finished creating a graphic
+                        // Either way, assume they want to disable the Map Point tool
+                        if ((IsToolActive && !HasPoint1) || (IsToolActive && HasPoint2))
+                        {
+                            Reset(true);
+                            IsToolActive = false;
+                            return;
+                        }
+
+                        // User has activated Map Point tool and created a point but not completed the graphic
+                        // Assume they want to cancel any graphic creation in progress 
+                        // but still keep the Map Point tool active
+                        if (IsToolActive && HasPoint1 && !HasPoint2)
+                        {
+                            Reset(false);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        // User has activated the Map Point tool but not created a point
+                        // Or User has previously finished creating a graphic
+                        // Either way, assume they want to disable the Map Point tool
+                        if ((IsToolActive && !HasPoint1) || (IsToolActive && HasPoint2))
+                        {
+                            Reset(true);
+                            IsToolActive = false;
+                            return;
+                        }
+
+                        // User has activated Map Point tool and created a point but not completed the graphic
+                        // Assume they want to cancel any graphic creation in progress 
+                        // but still keep the Map Point tool active
+                        if (IsToolActive && HasPoint1 && !HasPoint2)
+                        {
+                            Reset(false);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        
 
 
         /// <summary>

--- a/source/DistanceAndDirection/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProRangeViewModel.cs
+++ b/source/DistanceAndDirection/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProRangeViewModel.cs
@@ -354,6 +354,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             base.Reset(toolReset);
 
             NumberOfRadials = 0;
+            NumberOfRings = 10;
         }
 
         private void ConstructGeoCircle()

--- a/source/DistanceAndDirection/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/DistanceAndDirection/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
@@ -156,6 +156,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
 
         internal bool HasPoint1 = false;
         internal bool HasPoint2 = false;
+        internal bool HasPoint3 = false;
 
         public bool HasMapGraphics
         {
@@ -804,7 +805,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                     // User has activated the Map Point tool but not created a point
                     // Or User has previously finished creating a graphic
                     // Either way, assume they want to disable the Map Point tool
-                    if ((IsToolActive && !HasPoint1) || (IsToolActive && HasPoint2))
+                    if ((IsToolActive && !HasPoint1) || (IsToolActive && HasPoint3))
                     {
                         Reset(true);
                         IsToolActive = false;
@@ -814,7 +815,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                     // User has activated Map Point tool and created a point but not completed the graphic
                     // Assume they want to cancel any graphic creation in progress 
                     // but still keep the Map Point tool active
-                    if (IsToolActive && HasPoint1 && !HasPoint2)
+                    if (IsToolActive && HasPoint1)
                     {
                         Reset(false);
                         return;


### PR DESCRIPTION
Please review or reassign for review. This PR fixes Escape key not working properly for Ellipse tab in Pro, and adds Escape key functionality for ArcMap.