### PR TITLE
Fixes issue #198 - Circle tab

### DIFF
--- a/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
+++ b/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
@@ -89,6 +89,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
 
                 UpdateDistance(TravelTimeInSeconds * TravelRateInSeconds, RateUnit, true);
 
+                // Trigger validation to clear error messages as necessary
                 RaisePropertyChanged(() => TimeUnit);
                 RaisePropertyChanged(() => TravelTime);
                 RaisePropertyChanged(() => TravelRate);
@@ -177,8 +178,8 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 // we need to make sure we are in the same units as the Distance property before setting
                 UpdateDistance(TravelRateInSeconds * TravelTimeInSeconds, RateUnit, true);
                 RaisePropertyChanged(() => TravelTime);
-                
-                // Force an update of this in order to clear error message in bound WPF control
+
+                // Trigger validation to clear error messages as necessary
                 RaisePropertyChanged(() => TravelRate);
                 RaisePropertyChanged(() => RateTimeUnit);
                 RaisePropertyChanged(() => TimeUnit);
@@ -228,7 +229,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 UpdateDistance(TravelRateInSeconds * TravelTimeInSeconds, RateUnit, true);
                 RaisePropertyChanged(() => TravelRate);
 
-                // Force an update of this in order to clear error message in bound WPF control
+                // Trigger validation to clear error messages as necessary
                 RaisePropertyChanged(() => TravelTime);
                 RaisePropertyChanged(() => RateTimeUnit);
                 RaisePropertyChanged(() => TimeUnit);
@@ -313,6 +314,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
 
                 UpdateDistance(TravelTimeInSeconds * TravelRateInSeconds, RateUnit, true);
 
+                // Trigger validation to clear error messages as necessary
                 RaisePropertyChanged(() => RateTimeUnit);
                 RaisePropertyChanged(() => TravelTime);
                 RaisePropertyChanged(() => TravelRate);

--- a/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
+++ b/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
@@ -90,6 +90,8 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 UpdateDistance(TravelTimeInSeconds * TravelRateInSeconds, RateUnit, true);
 
                 RaisePropertyChanged(() => TimeUnit);
+                RaisePropertyChanged(() => TravelTime);
+                RaisePropertyChanged(() => TravelRate);
             }
         }
 
@@ -175,6 +177,11 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 // we need to make sure we are in the same units as the Distance property before setting
                 UpdateDistance(TravelRateInSeconds * TravelTimeInSeconds, RateUnit, true);
                 RaisePropertyChanged(() => TravelTime);
+                
+                // Force an update of this in order to clear error message in bound WPF control
+                RaisePropertyChanged(() => TravelRate);
+                RaisePropertyChanged(() => RateTimeUnit);
+                RaisePropertyChanged(() => TimeUnit);
             }
         }
 
@@ -220,6 +227,11 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
 
                 UpdateDistance(TravelRateInSeconds * TravelTimeInSeconds, RateUnit, true);
                 RaisePropertyChanged(() => TravelRate);
+
+                // Force an update of this in order to clear error message in bound WPF control
+                RaisePropertyChanged(() => TravelTime);
+                RaisePropertyChanged(() => RateTimeUnit);
+                RaisePropertyChanged(() => TimeUnit);
             }
         }
 
@@ -302,6 +314,8 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 UpdateDistance(TravelTimeInSeconds * TravelRateInSeconds, RateUnit, true);
 
                 RaisePropertyChanged(() => RateTimeUnit);
+                RaisePropertyChanged(() => TravelTime);
+                RaisePropertyChanged(() => TravelRate);
             }
         }
 

--- a/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
+++ b/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
@@ -77,7 +77,7 @@
                     </ToggleButton>
                 </Grid>
                 <TextBlock Margin="3,3,0,0" Text="{x:Static prop:Resources.LabelRadiusDiameter}" />
-                <TextBox x:Name="radiusDiameter" Margin="3,3,0,0"
+                <TextBox Margin="3,3,0,0"
                          Text="{Binding Path=DistanceString,
                                         UpdateSourceTrigger=PropertyChanged,
                                         ValidatesOnExceptions=True}"

--- a/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
+++ b/source/DistanceAndDirection/DistanceAndDirectionLibrary/Views/CircleView.xaml
@@ -77,7 +77,7 @@
                     </ToggleButton>
                 </Grid>
                 <TextBlock Margin="3,3,0,0" Text="{x:Static prop:Resources.LabelRadiusDiameter}" />
-                <TextBox Margin="3,3,0,0"
+                <TextBox x:Name="radiusDiameter" Margin="3,3,0,0"
                          Text="{Binding Path=DistanceString,
                                         UpdateSourceTrigger=PropertyChanged,
                                         ValidatesOnExceptions=True}"
@@ -137,11 +137,11 @@
                                                                        Path=.}" />
                             </TextBox.InputBindings>
                         </TextBox>
-                        <ComboBox 
+                        <ComboBox Validation.ErrorTemplate="{StaticResource errorTemplate}"
                                   Margin="3,3,0,0"
                                   ItemsSource="{Binding Source={StaticResource timeData}}"
-                                  SelectedItem="{Binding Path=TimeUnit,
-                                                         Mode=TwoWay}">
+                                  SelectedItem="{Binding Path=TimeUnit,Mode=TwoWay, ValidatesOnExceptions=True}"
+                                >
                             <ComboBox.InputBindings>
                                     <KeyBinding Key="Enter"
                                     Command="{Binding EnterKeyCommand}"
@@ -173,10 +173,11 @@
                             </TextBox.InputBindings>
                         </TextBox>
                         <ComboBox x:Name="cmbRateType"
+                                  Validation.ErrorTemplate="{StaticResource errorTemplate}"
                                   Margin="3,3,0,0"
                                   ItemsSource="{Binding Source={StaticResource rateTimeData}}"
                                   SelectedItem="{Binding Path=RateTimeUnit,
-                                                         Mode=TwoWay}">
+                                                         Mode=TwoWay,  ValidatesOnExceptions=True}" >
                             <ComboBox.InputBindings>
                                 <KeyBinding Key="Enter"
                                     Command="{Binding EnterKeyCommand}"


### PR DESCRIPTION
Please review.

Each time a control is changed that can alter the value in Radius / Diameter, if the new value of Radius / Diameter exceeds the DistanceLimit value (20000000 meters) an exception is thrown which results in the control (that was altered to cause the exception) being highlighted in red. If a subsequent input to a different control also results in Radius / Diameter being greater than DistanceLimit, that control will also be highlighted in red, so it is possible to see more than one control highlighted in red (including e.g. Time and Rate comboboxes).

All red exception warnings are cleared when changes to any single control bring the Radius / Diameter value below DistanceLimit.

I derived the value of 20000000m for DistanceLimit from experimentation. This seems to be sufficient to allow the circle to be large enough to encompass the entire earth, but low enough to block the glitches. I'm open to suggestion on a better value for this.