### PR TITLE
Fixes clearing Center Point textbox issue #200

### DIFF
--- a/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/DistanceAndDirection/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -757,8 +757,6 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 Point1 = point;
                 HasPoint1 = true;
                 
-                Point1Formatted = string.Empty;
-
                 var color = new RgbColorClass() { Green = 255 } as IColor;
                 AddGraphicToMap(Point1, color, true);
 


### PR DESCRIPTION
Please review or reassign. I cannot see any reason for the line:

Point1Formatted = string.Empty;

Especially as it seems to counteract the effect of the earlier line:

Point1 = point;

A brief functional test didn't reveal any issues.