### PR TITLE
Address Issue #441

### DIFF
--- a/source/widget/DistanceAndDirection/Widget.js
+++ b/source/widget/DistanceAndDirection/Widget.js
@@ -19,10 +19,12 @@ define([
   'dojo/aspect',
   'dojo/topic',
   'dojo/on',
+  'dojo/dom-style',
   'dijit/_WidgetsInTemplateMixin',
   'dijit/registry',
   'jimu/BaseWidget',
   'jimu/dijit/TabContainer3',
+  'dijit/layout/ContentPane',
   './views/TabLine',
   './views/TabCircle',
   './views/TabEllipse',
@@ -32,10 +34,12 @@ define([
   dojoAspect,
   dojoTopic,
   dojoOn,
+  domStyle,
   dijitWidgetsInTemplate,
   dijitRegistry,
   jimuBaseWidget,
   JimuTabContainer3,
+  ContentPane,
   TabLine,
   TabCircle,
   TabEllipse,
@@ -286,6 +290,11 @@ define([
             
             var tabContainer1 = dijitRegistry.byId('DDTabContainer');
             
+            // create an empty spacer tab so that we can control the width of the other tabs
+            var pane = new ContentPane({ title:"", href:""});            
+            tabContainer1.addTab(pane);
+            
+            // set width of other tabs to 60px and hide the spacer tab
             this.setTabWidths(tabContainer1);
     
             dojoAspect.after(tabContainer1, "selectTab", function() {
@@ -297,6 +306,9 @@ define([
           for(var i = 0; i < tabContainer.tabTr.cells.length - 1; i++) {
             tabContainer.tabTr.cells[i].width = '60px';
           }
+          domStyle.set(tabContainer.tabTr.cells[tabContainer.tabTr.cells.length - 1], {
+            "display": 'inline-block'
+          });          
         }
     });
     return clz;

--- a/source/widget/DistanceAndDirection/css/style.css
+++ b/source/widget/DistanceAndDirection/css/style.css
@@ -144,11 +144,12 @@
   display: none;
 }
 
+.jimu-widget-DistanceAndDirection .jimu-tab3 .tab-item-td {
+    border-bottom: 0px;
+}
+
 .jimu-widget-DistanceAndDirection .jimu-tab3 .tab-item-td.jimu-state-active {
-    border-bottom: 0px solid #24B5CC;
-    border-top: 2px solid #24B5CC;
-    border-left: 1px solid #ccc;
-    border-right: 1px solid #ccc;
+    border: 1px solid #24B5CC;
     background-color: transparent !important;
 }
 


### PR DESCRIPTION
It looks like there has been a change in the behaviour of the tab container at 2.5. Tabs within the container will always fill 100% of the width of the container, in previous releases there was a hidden tab that was always added that allowed you to control the width of the other tabs and this hidden tab would fill the gap to make it up to 100% width.

It looks like this hidden tab has been removed and the last tab width will change to make the tabs up to 100% width, so the fix was to manually add this hidden tab, a few CSS changes were also required to make the UI correct.