### PR TITLE
Found issue that IE does not support the includes function for an array

### DIFF
--- a/source/widget/DistanceAndDirection/views/TabRange.js
+++ b/source/widget/DistanceAndDirection/views/TabRange.js
@@ -460,7 +460,7 @@ define([
           return isNaN(data.value);          
         }));
       }
-      return !invalidValue.includes(true);
+      return invalidValue.indexOf(true) === -1;
     },
 
     /*


### PR DESCRIPTION
Changed the function to indexOf instead this works across all browsers