### PR TITLE
Check out of bounds during shape creation

### DIFF
--- a/source/addins/DistanceAndDirectionLibrary/Properties/Resources.Designer.cs
+++ b/source/addins/DistanceAndDirectionLibrary/Properties/Resources.Designer.cs
@@ -790,6 +790,15 @@ namespace DistanceAndDirectionLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Point is out of bounds.
+        /// </summary>
+        public static string MsgOutOfAOI {
+            get {
+                return ResourceManager.GetString("MsgOutOfAOI", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Edit Properties.
         /// </summary>
         public static string TitleEditProperties {

--- a/source/addins/DistanceAndDirectionLibrary/Properties/Resources.resx
+++ b/source/addins/DistanceAndDirectionLibrary/Properties/Resources.resx
@@ -360,6 +360,9 @@
   <data name="LabelTime" xml:space="preserve">
     <value>Time</value>
   </data>
+  <data name="MsgOutOfAOI" xml:space="preserve">
+    <value>Point is out of bounds</value>
+  </data>
   <data name="TitleEditProperties" xml:space="preserve">
     <value>Edit Properties</value>
   </data>


### PR DESCRIPTION
This fix addresses the [issue](https://github.com/ArcGIS/solutions-defense/issues/437) of a user potentially creating a shape (line, circle, ellipse or rings) outside of the area of interest of a map. 