### PR TITLE
Fixes #216

### DIFF
--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
@@ -210,17 +210,22 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
         // when someone hits the enter key, create geodetic graphic
         internal override void OnEnterKeyCommand(object obj)
         {
-
+            string outFormattedString = string.Empty;
+            CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Models.CoordinateType.Unknown;
             if (LineFromType == LineFromTypes.Points)
             {
-                Point1 = GetPointFromString(Point1Formatted);
-                Point2 = GetPointFromString(Point2Formatted);
+                ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(Point1Formatted, out outFormattedString);
+                Point1 = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null; //GetPointFromString(Point1Formatted);
+
+                ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(Point2Formatted, out outFormattedString);
+                Point2 = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null; //GetPointFromString(Point2Formatted);
                 if (!Azimuth.HasValue || Point1 == null || Point2 == null)
                     return;
             }
             else
             {
-                Point1 = GetPointFromString(Point1Formatted);
+                ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(Point1Formatted, out outFormattedString);
+                Point1 = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null; //GetPointFromString(Point1Formatted);
                 if (!Azimuth.HasValue || Point1 == null)
                     return;
             }

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
@@ -215,17 +215,17 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             if (LineFromType == LineFromTypes.Points)
             {
                 ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(Point1Formatted, out outFormattedString);
-                Point1 = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null; //GetPointFromString(Point1Formatted);
+                Point1 = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
 
                 ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(Point2Formatted, out outFormattedString);
-                Point2 = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null; //GetPointFromString(Point2Formatted);
+                Point2 = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
                 if (!Azimuth.HasValue || Point1 == null || Point2 == null)
                     return;
             }
             else
             {
                 ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(Point1Formatted, out outFormattedString);
-                Point1 = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null; //GetPointFromString(Point1Formatted);
+                Point1 = (ccType != CoordinateConversionLibrary.Models.CoordinateType.Unknown) ? GetPointFromString(outFormattedString) : null;
                 if (!Azimuth.HasValue || Point1 == null)
                     return;
             }


### PR DESCRIPTION
This fixes the missing step of converting coordinates to its appropriate notation using the CC library during the `Enter` key-pressed event.

@csmoore Can you review please? Thanks.