### PR TITLE
Addresses #476

### DIFF
--- a/source/addins/DistanceAndDirectionLibrary/Helpers/Constants.cs
+++ b/source/addins/DistanceAndDirectionLibrary/Helpers/Constants.cs
@@ -25,5 +25,6 @@ namespace DistanceAndDirectionLibrary
         public const string MOUSE_DOUBLE_CLICK = "MOUSE_DOUBLE_CLICK";
         public const string KEYPRESS_ESCAPE = "KEYPRESS_ESCAPE";
         public const string POINT_TEXT_KEYDOWN = "POINT_TEXT_KEYDOWN";
+        public const string RADIUS_DIAMETER_KEYDOWN = "RADIUS_DIAMETER_KEYDOWN";
     }
 }

--- a/source/addins/DistanceAndDirectionLibrary/Views/CircleView.xaml
+++ b/source/addins/DistanceAndDirectionLibrary/Views/CircleView.xaml
@@ -82,7 +82,7 @@
                          Text="{Binding Path=DistanceString,
                                         UpdateSourceTrigger=PropertyChanged,
                                         ValidatesOnExceptions=True}"
-                         Validation.ErrorTemplate="{StaticResource errorTemplate}">
+                         Validation.ErrorTemplate="{StaticResource errorTemplate}" PreviewKeyDown="Radius_Diameter_KeyDown">
                     <TextBox.InputBindings>
                         <KeyBinding Key="Enter"
                                     Command="{Binding EnterKeyCommand}"

--- a/source/addins/DistanceAndDirectionLibrary/Views/CircleView.xaml.cs
+++ b/source/addins/DistanceAndDirectionLibrary/Views/CircleView.xaml.cs
@@ -30,5 +30,10 @@ namespace DistanceAndDirectionLibrary.Views
         {
             DistanceAndDirectionLibrary.Helpers.Mediator.NotifyColleagues(DistanceAndDirectionLibrary.Constants.POINT_TEXT_KEYDOWN, null);
         }
+
+        private void Radius_Diameter_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            DistanceAndDirectionLibrary.Helpers.Mediator.NotifyColleagues(DistanceAndDirectionLibrary.Constants.RADIUS_DIAMETER_KEYDOWN, null);
+        }
     }
 }

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProCircleViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProCircleViewModel.cs
@@ -574,7 +574,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
 
                     // divide the manual input by 2
                     double dist = 0.0;
-                    if (CircleType == CircleFromTypes.Diameter)
+                    if (CircleType == CircleFromTypes.Diameter && isManualRadiusDiameterEntered)
                         dist = d / 2.0;
                     else
                         dist = d;
@@ -622,6 +622,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             {
                 return;
             }
+            isManualRadiusDiameterEntered = false;
             base.OnEnterKeyCommand(obj);
         }
 

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
@@ -57,6 +57,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             Mediator.Register(DistanceAndDirectionLibrary.Constants.TAB_ITEM_SELECTED, OnTabItemSelected);
             Mediator.Register(DistanceAndDirectionLibrary.Constants.KEYPRESS_ESCAPE, OnKeypressEscape);
             Mediator.Register(DistanceAndDirectionLibrary.Constants.POINT_TEXT_KEYDOWN, OnPointTextBoxKeyDown);
+            Mediator.Register(DistanceAndDirectionLibrary.Constants.RADIUS_DIAMETER_KEYDOWN, OnRadiusDiameterTextBoxKeyDown);
 
             // Pro Events
             // Note: will fail if called from Unit Tests, so catch exception for this case
@@ -105,6 +106,10 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
         #endregion
 
         #region Properties
+        /// <summary>
+        /// Property to keep track of manual entry for radius or diameter value
+        /// </summary>
+        public bool isManualRadiusDiameterEntered { get; set; }
 
         private bool isActiveTab = false;
         /// <summary>
@@ -874,6 +879,9 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                         return;
                     }
                 }
+
+                //Clear manual flag for radius/diameter property
+                isManualRadiusDiameterEntered = false;
             }
         }
 
@@ -889,6 +897,15 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                 if (IsToolActive)
                     IsToolActive = false;
             }
+        }
+
+        /// <summary>
+        /// Handler for when key is manually pressed in the Radius/Diameter text box
+        /// </summary>
+        /// <param name="obj"></param>
+        private void OnRadiusDiameterTextBoxKeyDown(object obj)
+        {
+            isManualRadiusDiameterEntered = true;
         }
 
         internal double ConvertFromTo(DistanceTypes fromType, DistanceTypes toType, double input)


### PR DESCRIPTION
The circle feedback goes haywire when trying a user creates a circle using `Diameter` option. The feedback is now fixed and follows the cursor's movement appropriately.

See: #476 
