### PR TITLE
Address #533 and #534

### DIFF
--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
@@ -913,7 +913,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                         }
 
                         //Add text using centroid point
-                        this.AddTextToMap(area.Centroid, string.Format("{0}:{1} {2}",
+                        this.AddTextToMap(area.LabelPoint, string.Format("{0}:{1} {2}",
                             circleTypeLabel,
                             distanceLabel,
                             unitLabel));

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/EllipseViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/EllipseViewModel.cs
@@ -688,7 +688,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
 
                         if (area != null)
                         {                  
-                            AddTextToMap(area.Centroid, string.Format("{0}:{1} {2}{3}{4}:{5} {6}{7}{8}:{9} {10}",
+                            AddTextToMap(area.LabelPoint, string.Format("{0}:{1} {2}{3}{4}:{5} {6}{7}{8}:{9} {10}",
                                 "Major Axis",
                                 Math.Round(majAxisDist, 2),
                                 dtVal.ToString(),

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
@@ -317,7 +317,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                         Environment.NewLine,
                         "Angle",
                         Math.Round(azimuth.Value,2),
-                        atVal.ToString()), (double)Azimuth, LineAzimuthType);
+                        atVal.ToString()), (double)Azimuth, LineAzimuthType, false);
                 }
 
                 ResetPoints();

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -1295,7 +1295,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
 
             //Check if the geometry exists in the graphics list. 
             //If so, then exit
-            if (GraphicsList.Any(g => ((IRelationalOperator)g.Geometry).Equals(geom)))
+            if (GraphicsList.Any(g => ((IRelationalOperator)g.Geometry).Equals(geom) && g.GraphicType == GraphicTypes.Line))
                 return;
 
             IElement element = null;

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -1223,7 +1223,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             RaisePropertyChanged(() => HasMapGraphics);
         }
 
-        internal void AddTextToMap(IGeometry geom, string text, double angle, AzimuthTypes azimuthType)
+        internal void AddTextToMap(IGeometry geom, string text, double angle, AzimuthTypes azimuthType, bool hasRotation = true)
         {
             if ((ArcMap.Application == null) || (ArcMap.Application.Document == null))
                 return;
@@ -1256,7 +1256,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             textEle.Text = text;
             ITextSymbol tsym = new TextSymbol();
 
-            tsym.Angle = 0;//rotate - rotation was removed per issue #289
+            tsym.Angle = (hasRotation) ? rotate : 0;
             tsym.HorizontalAlignment = esriTextHorizontalAlignment.esriTHALeft;
             textEle.Symbol = tsym;
             var elem = (IElement)textEle;


### PR DESCRIPTION
This fix addresses #533 for circles and ellipses. Labels are rendered using the IArea::LabelPoint property. Range rings is still an issue.

The [last commit](https://github.com/Esri/distance-direction-addin-dotnet/pull/536/commits/e0e3ed318d0daf1984c9fcf1ac8ef381a4c136a1) fixes #534 which was introduced when a fix was implemented for #419. The check for duplicate geometry had to be more specific where a check for duplicate lines were needed.