### PR TITLE
Labels for Range Rings created outside of Basemap extent

### DIFF
--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
@@ -387,62 +387,6 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 System.Diagnostics.Debug.WriteLine(ex);
             }
         }
-
-        /// <summary>
-        /// Creates the international dateline as a polyline geometry
-        /// 
-        /// Source: https://github.com/Esri/developer-support/blob/master/arcobjects-net/international-dateline-draw-line-across/CreateLine.cs
-        /// </summary>
-        /// <returns>Polyline geometry</returns>
-        private IPolyline GetIntDateline()
-        {
-            try
-            {
-                //Create WGS84
-                Type factoryType = Type.GetTypeFromProgID("esriGeometry.SpatialReferenceEnvironment");
-                var obj = Activator.CreateInstance(factoryType);
-                var srf = obj as ISpatialReferenceFactory3;
-                var WGS84 = srf.CreateSpatialReference(esriSRGeoCSType.esriSRGeoCS_WGS1984.GetHashCode());
-
-                var pointCollection = new PolylineClass();
-
-                // ------------- Ensure that both points have negative longitude values -------------------
-                var point = new PointClass();
-                point.PutCoords(180, 90); // Equivalent to 170 degrees WEST
-                point.SpatialReference = WGS84;
-                pointCollection.AddPoint(point);
-
-
-                point = new PointClass();
-                point.PutCoords(180, -90); // Equivalent to 160 degrees EAST
-                point.SpatialReference = WGS84;
-                pointCollection.AddPoint(point);
-                // -----------------------------------------------------------------------
-
-                var polyline = (IPolyline)pointCollection;
-                polyline.SpatialReference = WGS84;
-
-                polyline.Project(ArcMap.Document.FocusMap.SpatialReference);
-
-                return polyline;
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine(ex.Message);
-            }            
-            return null;
-        }
-
-        /// <summary>
-        /// Checks if a polyline geometry crosses the international dateline
-        /// </summary>
-        /// <param name="inputLine"></param>
-        /// <returns>bool</returns>
-        private bool DoesLineCrossIntDateline(IPolyline inputLine)
-        {                        
-            return (inputLine != null) ? ((IRelationalOperator)inputLine).Crosses(GetIntDateline()) : false;
-        }
-
         #endregion
 
         #region Mediator methods

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/RangeViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/RangeViewModel.cs
@@ -437,8 +437,14 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 construct.ConstructGeodesicCircle(Point1, GetLinearUnit(), -Distance, esriCurveDensifyMethod.esriCurveDensifyByAngle, 0.45);
                 // Create a non geodesic circle
                 var circleGeom = CreateCircleGeometry(Point1, maxDistance);
-                // Check if circle is within the basemap extent.
-                var isWithin = IsGeometryWithinExtent(circleGeom, GetBasemapExtent(ArcMap.Document.FocusMap));
+                // Get the basemap extent
+                var basemapExt = GetBasemapExtent(ArcMap.Document.FocusMap);
+                // Check if circle is within the basemap extent. If circle is within basemap boundary,
+                // then use the geodesic circle for labeling. If it's not, then use the non-geodesic 
+                // circle to label.
+                bool isWithin = true;
+                if (basemapExt != null)
+                    isWithin = IsGeometryWithinExtent(circleGeom, basemapExt);
                 AddTextToMap((isWithin) ? (IGeometry)construct : circleGeom, String.Format("{0} {1}", Math.Round(Distance, 2).ToString(), lineDistanceType.ToString()));
             }
         }

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/RangeViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/RangeViewModel.cs
@@ -430,12 +430,16 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
 
                 construct.ConstructGeodesicCircle(Point1, GetLinearUnit(), Distance, esriCurveDensifyMethod.esriCurveDensifyByAngle, 0.45);
                 Point2 = ((IPolyline)construct).ToPoint;
-                this.AddGraphicToMap(construct as IGeometry, color, attributes: rrAttributes);
+                AddGraphicToMap(construct as IGeometry, color, attributes: rrAttributes);
                 maxDistance = Math.Max(Distance, maxDistance);
 
                 // Use negative Distance to get the location for the distance label
                 construct.ConstructGeodesicCircle(Point1, GetLinearUnit(), -Distance, esriCurveDensifyMethod.esriCurveDensifyByAngle, 0.45);
-                this.AddTextToMap(construct as IGeometry, String.Format("{0} {1}", Math.Round(Distance, 2).ToString(), lineDistanceType.ToString()));
+                // Create a non geodesic circle
+                var circleGeom = CreateCircleGeometry(Point1, maxDistance);
+                // Check if circle is within the basemap extent.
+                var isWithin = IsGeometryWithinExtent(circleGeom, GetBasemapExtent(ArcMap.Document.FocusMap));
+                AddTextToMap((isWithin) ? (IGeometry)construct : circleGeom, String.Format("{0} {1}", Math.Round(Distance, 2).ToString(), lineDistanceType.ToString()));
             }
         }
 

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -985,8 +985,6 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 return ((IRelationalOperator)inputGeom).Within(searchExtent);
             }
             return true;
-            //return (inputGeom != null && searchExtent != null) ? 
-            //    ((IRelationalOperator)inputGeom).Within(searchExtent) : false;
         }
         
         /// <summary>
@@ -1004,7 +1002,6 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             var segCollection = new PolylineClass();
             segCollection.AddSegment(seg);
             var geom = (IGeometry)segCollection;
-            //geom.Project(ArcMap.Document.FocusMap.SpatialReference); //Reproject to match current spatial reference
             return geom;
         }
 

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -942,6 +942,68 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
         }
 
         /// <summary>
+        /// Returns the extent of a basemap
+        /// </summary>
+        /// <param name="map">IMap interface</param>
+        /// <returns>IEnvelope interface</returns>
+        internal IEnvelope GetBasemapExtent(IMap map)
+        {
+            try
+            {
+                ILayer basemapLayer = null;
+                var layers = map.get_Layers();
+                var layer = layers.Next();
+                while (layer != null)
+                {
+                    if (layer is ICompositeLayer)
+                    {
+                        basemapLayer = layer;
+                        break;
+                    }
+                    layer = layers.Next();
+                }
+                if (basemapLayer != null)
+                {
+                    return basemapLayer.AreaOfInterest;
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(ex.Message);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Checks if a input geometry is within an extent
+        /// </summary>
+        /// <param name="inputGeom">Input Geometry</param>
+        /// <param name="searchExtent">Search Extent</param>
+        /// <returns>bool</returns>
+        internal bool IsGeometryWithinExtent(IGeometry inputGeom, IEnvelope searchExtent)
+        {
+            return (inputGeom != null && searchExtent != null) ? 
+                ((IRelationalOperator)inputGeom).Within(searchExtent) : false;
+        }
+        
+        /// <summary>
+        /// Creates a circle geometry based on center point and radius
+        /// </summary>
+        /// <param name="centerPoint">IPoint - Center Point </param>
+        /// <param name="radius">double - Radius</param>
+        /// <returns>IGeometry</returns>
+        internal IGeometry CreateCircleGeometry(IPoint centerPoint, double radius)
+        {
+            var circularArc = new CircularArcClass();
+            var construtionCircularArc = (IConstructCircularArc)circularArc;
+            construtionCircularArc.ConstructCircle(centerPoint, radius, true);
+            var seg = (ISegment)construtionCircularArc;
+            var segCollection = new PolylineClass();
+            segCollection.AddSegment(seg);
+            return (IGeometry)segCollection;
+        }
+
+        /// <summary>
         /// Unions all extents 
         /// </summary>
         /// <param name="map"></param>
@@ -1239,15 +1301,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             if (gc == null)
                 return;
 
-            double bearing = 0.0;
-            if (azimuthType == AzimuthTypes.Mils)
-            {
-                bearing = angle * 0.05625;
-            }
-            else
-            {
-                bearing = angle;
-            }
+            double bearing = (azimuthType == AzimuthTypes.Mils) ? angle * 0.05625 : angle;
 
             double rotate = 360 - (bearing + 270.0) % 360;
             if (rotate > 90 && rotate <= 270)
@@ -1257,7 +1311,8 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             ITextSymbol tsym = new TextSymbol();
 
             tsym.Angle = (hasRotation) ? rotate : 0;
-            tsym.HorizontalAlignment = esriTextHorizontalAlignment.esriTHALeft;
+            if (!hasRotation)
+                tsym.HorizontalAlignment = esriTextHorizontalAlignment.esriTHALeft;
             textEle.Symbol = tsym;
             var elem = (IElement)textEle;
             elem.Geometry = geom;
@@ -1268,9 +1323,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             if (geom.GeometryType == esriGeometryType.esriGeometryPoint)
                 GraphicsList.Add(new Graphic(GraphicTypes.Point, eprop.Name, geom, this, false));
             else if (this is LinesViewModel)
-            {
                 GraphicsList.Add(new Graphic(GraphicTypes.Line, eprop.Name, geom, this, false));
-            }
             else if (this is CircleViewModel)
                 GraphicsList.Add(new Graphic(GraphicTypes.Circle, eprop.Name, geom, this, false));
             else if (this is EllipseViewModel)

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -955,7 +955,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 var layer = layers.Next();
                 while (layer != null)
                 {
-                    if (layer is ICompositeLayer)
+                    if (layer is IBasemapLayer)
                     {
                         basemapLayer = layer;
                         break;


### PR DESCRIPTION
This fix addresses #533 for range rings. Logic implemented:
1. Gets the basemap extents
2. Creates a non-geodesic circle
3. Checks if circle crosses beyond basemap extent
 a. If so, then create label based on non-geodesic circle
 b. If not, then create label based on geodesic range ring circle

@csmoore Can you review? Thanks.