### PR TITLE
Checking for NaN distance

### DIFF
--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
@@ -392,6 +392,10 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             {
                 if (value < 0.0)
                     throw new ArgumentException(DistanceAndDirectionLibrary.Properties.Resources.AEMustBePositive);
+                
+                // Prevents a stack overflow if the point is past -180 latitude, for example
+                if (double.IsNaN(value))
+                    return;
 
                 distance = value;
                 DistanceString = distance.ToString("G");


### PR DESCRIPTION
If the set value is `NaN` (not a number), it causes the `DistanceString` setter to call the `Distance` setter again, which calls the `DistanceString` setter again, which calls the `Distance` setter again, which calls the `DistanceString` setter again...until the stack overflows. We can prevent this infinite loop and stack overflow if we check here and return if the set value is `NaN`.

To test this behavior and this fix, build the add-in, deploy in ArcGIS Pro, and use the Circle tab of the Distance and Direction add-in to draw a circle on a 2D map. When you move the mouse west of -180 degrees longitude, ArcGIS Pro crashes without this fix. With the fix, the circle stops drawing and the distance value stops changing until the mouse is back on the map.