### PR TITLE
Added validation check for start and end point being the same

### DIFF
--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -278,6 +278,15 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                     RaisePropertyChanged(() => Point2Formatted);
                     return;
                 }
+
+                // Point1Formatted should never equal to Point2Formatted
+                if (Point1Formatted.ToLower().Trim().Equals(value.ToLower().Trim()))
+                {
+                    Point2 = null;
+                    HasPoint2 = false;
+                    throw new ArgumentException(DistanceAndDirectionLibrary.Properties.Resources.EndPointAndStartPointSameError);
+                }
+
                 // try to convert string to an IPoint
                 string outFormattedString = string.Empty;
                 CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(value, out outFormattedString);

--- a/source/addins/DistanceAndDirectionLibrary/Properties/Resources.Designer.cs
+++ b/source/addins/DistanceAndDirectionLibrary/Properties/Resources.Designer.cs
@@ -142,6 +142,15 @@ namespace DistanceAndDirectionLibrary.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ending Point should not be the same as the Starting Point.
+        /// </summary>
+        public static string EndPointAndStartPointSameError {
+            get {
+                return ResourceManager.GetString("EndPointAndStartPointSameError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Distance and Bearing.
         /// </summary>
         public static string EnumBearingAndDistance {

--- a/source/addins/DistanceAndDirectionLibrary/Properties/Resources.resx
+++ b/source/addins/DistanceAndDirectionLibrary/Properties/Resources.resx
@@ -144,6 +144,9 @@
   <data name="DistanceDirectionLabel" xml:space="preserve">
     <value>Distance and Direction</value>
   </data>
+  <data name="EndPointAndStartPointSameError" xml:space="preserve">
+    <value>Ending Point should not be the same as the Starting Point</value>
+  </data>
   <data name="EnumBearingAndDistance" xml:space="preserve">
     <value>Distance and Bearing</value>
   </data>

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
@@ -338,6 +338,14 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                     return;
                 }
 
+                // Point1Formatted should never equal to Point2Formatted
+                if (Point1Formatted.ToLower().Trim().Equals(value.ToLower().Trim()))
+                {
+                    Point2 = null;
+                    HasPoint2 = false;
+                    throw new ArgumentException(DistanceAndDirectionLibrary.Properties.Resources.EndPointAndStartPointSameError);
+                }
+
                 // try to convert string to a MapPoint
                 string outFormattedString = string.Empty;
                 CoordinateConversionLibrary.Models.CoordinateType ccType = CoordinateConversionLibrary.Helpers.ConversionUtils.GetCoordinateString(value, out outFormattedString);


### PR DESCRIPTION
This fix will check if the supplied start and end points are the same. if so, then throw an exception. 