### PR TITLE
#591 - Clear Button not always enabled

### DIFF
--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProCircleViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProCircleViewModel.cs
@@ -804,6 +804,8 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             await QueuedTask.Run(async () =>
                 message = await AddFeatureToLayer(geom, circleAttributes));
 
+            RaisePropertyChanged(() => HasMapGraphics);
+
             if (!string.IsNullOrEmpty(message))
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(message,
                     DistanceAndDirectionLibrary.Properties.Resources.ErrorFeatureCreateTitle);

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProEllipseViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProEllipseViewModel.cs
@@ -593,6 +593,8 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             await QueuedTask.Run(async () =>
                 message = await AddFeatureToLayer(geom, ellipseAttributes));
 
+            RaisePropertyChanged(() => HasMapGraphics);
+
             if (!string.IsNullOrEmpty(message))
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(message,
                     DistanceAndDirectionLibrary.Properties.Resources.ErrorFeatureCreateTitle);

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProLinesViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProLinesViewModel.cs
@@ -585,6 +585,8 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             await QueuedTask.Run(async () =>
                 message = await AddFeatureToLayer(geom, lineAttributes));
 
+            RaisePropertyChanged(() => HasMapGraphics);
+
             if (!string.IsNullOrEmpty(message))
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(message,
                     DistanceAndDirectionLibrary.Properties.Resources.ErrorFeatureCreateTitle);

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProRangeViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProRangeViewModel.cs
@@ -444,6 +444,8 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             await QueuedTask.Run(async () =>
                 message = await AddFeatureToLayer(geom, rangeAttributes));
 
+            RaisePropertyChanged(() => HasMapGraphics);
+
             if (!string.IsNullOrEmpty(message))
                 ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show(message,
                     DistanceAndDirectionLibrary.Properties.Resources.ErrorFeatureCreateTitle);

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
@@ -176,10 +176,12 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             get
             {
                 // Call helper method (must be run on MCT)
-                return QueuedTask.Run<bool>(() =>
+                bool hasFeatures = QueuedTask.Run<bool>(async() =>
                 {
-                    return this.HasLayerFeatures();
+                    return await this.HasLayerFeatures();
                 }).Result;
+
+                return hasFeatures;
             }
         }
 
@@ -542,8 +544,6 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                     var gt = GetGraphicType();
 
                     GraphicsList.Add(new Graphic(gt, disposable, geom, this, p, IsTempGraphic));
-
-                    RaisePropertyChanged(() => HasMapGraphics);
                 });
         }
 
@@ -603,7 +603,6 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                     GraphicsList.Remove(item);
                 }
             }
-            RaisePropertyChanged(() => HasMapGraphics);
         }
 
         /// <summary>


### PR DESCRIPTION
Fix to Clear Button not always enabled after add feature - see: #591

Changes:

1. Awaited call to check feature count
2. Moved PropertyChanged event to Add Features from ClearGraphics