### PR TITLE
Change Save-As format

### DIFF
--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/Models/FeatureClassUtils.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/Models/FeatureClassUtils.cs
@@ -39,28 +39,28 @@ namespace ProAppDistanceAndDirectionModule.Models
 {
     class FeatureClassUtils
     {
-        private string previousLocation = "";
-        private string previousSaveType = "";
+        private string previousLocation = string.Empty;
+        private string previousSaveType = string.Empty;
 
         /// <summary>
         /// Prompts the user to save features
-        /// 
         /// </summary>
-        /// <returns>The path to selected output (fgdb/shapefile)</returns>
-        public string PromptUserWithSaveDialog(bool featureChecked, bool shapeChecked, bool kmlChecked)
+        /// <param name="featureShapeChecked"></param>
+        /// <returns></returns>
+        public string PromptUserWithSaveDialog(bool featureShapeChecked)
         {
             //Prep the dialog
             SaveItemDialog saveItemDlg = new SaveItemDialog();
             saveItemDlg.Title = "Select output";
             saveItemDlg.OverwritePrompt = true;
-            string saveType = featureChecked ? "gdb" : "file";
+            var saveType = (featureShapeChecked) ? "feature-shape" : "kml";
             if (string.IsNullOrEmpty(previousSaveType))
                 previousSaveType = saveType;
             if (!string.IsNullOrEmpty(previousLocation) && previousSaveType == saveType)
                 saveItemDlg.InitialLocation = previousLocation;
             else
             {
-                if (featureChecked)
+                if (featureShapeChecked)
                     saveItemDlg.InitialLocation = ArcGIS.Desktop.Core.Project.Current.DefaultGeodatabasePath;
                 else
                     saveItemDlg.InitialLocation = ArcGIS.Desktop.Core.Project.Current.HomeFolderPath;
@@ -68,16 +68,9 @@ namespace ProAppDistanceAndDirectionModule.Models
             previousSaveType = saveType;
 
             // Set the filters and default extension
-            if (featureChecked)
-            {
-                saveItemDlg.Filter = ItemFilters.geodatabaseItems_all;
-            }
-            else if (shapeChecked)
-            {
-                saveItemDlg.Filter = ItemFilters.shapefiles;
-                saveItemDlg.DefaultExt = "shp";
-            }
-            else if (kmlChecked)
+            if (featureShapeChecked)
+                saveItemDlg.Filter = ItemFilters.featureClasses_all;
+            else
             {
                 saveItemDlg.Filter = ItemFilters.kml;
                 saveItemDlg.DefaultExt = "kmz";
@@ -95,13 +88,6 @@ namespace ProAppDistanceAndDirectionModule.Models
                         MessageBoxImage.Exclamation);
                     return null;
                 } 
-                if (featureChecked && saveItemDlg.FilePath.IndexOf(".gdb") == -1)
-                {
-                    MessageBox.Show(DistanceAndDirectionLibrary.Properties.Resources.FeatureClassNameError,
-                        DistanceAndDirectionLibrary.Properties.Resources.DistanceDirectionLabel, MessageBoxButton.OK,
-                        MessageBoxImage.Exclamation);
-                    return null;
-                }
                 previousLocation = Path.GetDirectoryName(saveItemDlg.FilePath);                
                 return saveItemDlg.FilePath;           
             }

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProSaveAsFormatViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProSaveAsFormatViewModel.cs
@@ -15,38 +15,25 @@
   *   limitations under the License. 
   ******************************************************************************/
 
+using DistanceAndDirectionLibrary.ViewModels;
+
 namespace ProAppDistanceAndDirectionModule.ViewModels
 {
-    class ProSaveAsFormatViewModel : ProTabBaseViewModel
+    class ProSaveAsFormatViewModel : BaseViewModel
     {
 
-        private bool featureIsChecked = true;
-        public bool FeatureIsChecked
+        private bool featureShapeIsChecked = true;
+        public bool FeatureShapeIsChecked
         {
             get
             {
-                return featureIsChecked;
+                return featureShapeIsChecked;
             }
 
             set
             {
-                featureIsChecked = value;
-                RaisePropertyChanged(() => FeatureIsChecked);
-            }
-        }
-
-        private bool shapeIsChecked = false;
-        public bool ShapeIsChecked
-        {
-            get
-            {
-                return shapeIsChecked;
-            }
-
-            set
-            {
-                shapeIsChecked = value;
-                RaisePropertyChanged(() => ShapeIsChecked);
+                featureShapeIsChecked = value;
+                RaisePropertyChanged(() => FeatureShapeIsChecked);
             }
         }
 

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
@@ -1159,34 +1159,29 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                 System.Diagnostics.Trace.WriteLine("Unable to clear selected features");
             }
 
-            var dlg = new ProSaveAsFormatView();
+            var dlg = new GRSaveAsFormatView();
             dlg.DataContext = new ProSaveAsFormatViewModel();
             var vm = (ProSaveAsFormatViewModel)dlg.DataContext;
 
             if (dlg.ShowDialog() == true)
-            {
-                string path = fcUtils.PromptUserWithSaveDialog(vm.FeatureIsChecked, vm.ShapeIsChecked, vm.KmlIsChecked);
+            {                
+                string path = fcUtils.PromptUserWithSaveDialog(vm.FeatureShapeIsChecked);
                 if (path != null)
                 {
                     bool success = false;
-
                     try
-                    {
+                    {                        
                         string folderName = System.IO.Path.GetDirectoryName(path);
 
                         SaveAsType saveAsType = SaveAsType.FileGDB;
-
-                        if (vm.ShapeIsChecked)
+                        if (path.IndexOf(".gdb") == -1)
                             saveAsType = SaveAsType.Shapefile;
                         if (vm.KmlIsChecked)
                             saveAsType = SaveAsType.KML;
 
                         _progressDialog = new ProgressDialog("Exporting Layer: " + this.GetLayerName());
-
                         _progressDialog.Show();
-
                         success = await fcUtils.ExportLayer(this.GetLayerName(), path, saveAsType);
-
                         _progressDialog.Hide();
                     }
                     catch (Exception ex)
@@ -1195,7 +1190,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                     }
 
                     if (!success)
-                        ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Save As failed.");
+                        ArcGIS.Desktop.Framework.Dialogs.MessageBox.Show("Save As process failed.");
                 }
             }
         }


### PR DESCRIPTION
This addresses a new request from @topowright and @dfoll for issue #385 on how the `Save-As` should work. The new `Save-As` dialog in Pro now looks like this:

![image](https://user-images.githubusercontent.com/6391826/40981925-1d68c076-68aa-11e8-94f2-6cada753becd.png)
