### PR TITLE
#591 Clear Button Redo

### DIFF
--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/CircleViewModel.cs
@@ -424,7 +424,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                         return DistanceTypes.Miles;
                     case RateTimeTypes.NauticalMilesHour:
                     case RateTimeTypes.NauticalMilesSec:
-                        return DistanceTypes.NauticalMile;
+                        return DistanceTypes.NauticalMiles;
                     default:
                         return DistanceTypes.Meters;
                 }
@@ -861,7 +861,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                                     unitLabel = RateUnit.ToString();
                                     roundingFactor = 2;
                                     break;
-                                case DistanceTypes.NauticalMile:
+                                case DistanceTypes.NauticalMiles:
                                     unitLabel = "Nautical Miles";
                                     roundingFactor = 2;
                                     break;
@@ -887,7 +887,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                                     unitLabel = RateUnit.ToString();
                                     roundingFactor = 2;
                                     break;
-                                case DistanceTypes.NauticalMile:
+                                case DistanceTypes.NauticalMiles:
                                     unitLabel = "Nautical Miles";
                                     roundingFactor = 2;
                                     break;

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/TabBaseViewModel.cs
@@ -1516,7 +1516,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 case DistanceTypes.Miles:
                     unitType = (int)esriSRUnitType.esriSRUnit_SurveyMile;
                     break;
-                case DistanceTypes.NauticalMile:
+                case DistanceTypes.NauticalMiles:
                     unitType = (int)esriSRUnitType.esriSRUnit_NauticalMile;
                     break;
                 case DistanceTypes.Yards:
@@ -1569,7 +1569,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
             {
                 case DistanceTypes.Kilometers:
                 case DistanceTypes.Miles:
-                case DistanceTypes.NauticalMile:
+                case DistanceTypes.NauticalMiles:
                     returnDistance = Math.Round(inputDistance, largeUnitRoundingFactor);
                     break;
                 case DistanceTypes.Meters:
@@ -1601,7 +1601,7 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 case DistanceTypes.Miles:
                     unit = esriUnits.esriMiles;
                     break;
-                case DistanceTypes.NauticalMile:
+                case DistanceTypes.NauticalMiles:
                     unit = esriUnits.esriNauticalMiles;
                     break;
                 case DistanceTypes.Yards:

--- a/source/addins/DistanceAndDirectionLibrary/Enums/Enums.cs
+++ b/source/addins/DistanceAndDirectionLibrary/Enums/Enums.cs
@@ -54,7 +54,7 @@ namespace DistanceAndDirectionLibrary
         Miles = 4,
         
         [LocalizableDescription(@"EnumNauticalMile", typeof(Resources))]
-        NauticalMile = 5,
+        NauticalMiles = 5,
 
         [LocalizableDescription(@"EnumYards", typeof(Resources))]
         Yards = 6

--- a/source/addins/DistanceAndDirectionLibrary/Properties/Resources.Designer.cs
+++ b/source/addins/DistanceAndDirectionLibrary/Properties/Resources.Designer.cs
@@ -403,7 +403,7 @@ namespace DistanceAndDirectionLibrary.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Nautical Mile.
+        ///   Looks up a localized string similar to Nautical Miles.
         /// </summary>
         public static string EnumNauticalMile {
             get {

--- a/source/addins/DistanceAndDirectionLibrary/Properties/Resources.resx
+++ b/source/addins/DistanceAndDirectionLibrary/Properties/Resources.resx
@@ -232,7 +232,7 @@
     <value>Mils</value>
   </data>
   <data name="EnumNauticalMile" xml:space="preserve">
-    <value>Nautical Mile</value>
+    <value>Nautical Miles</value>
   </data>
   <data name="EnumNauticalMilesHour" xml:space="preserve">
     <value>Nautical Miles / Hour</value>

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProCircleViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProCircleViewModel.cs
@@ -414,7 +414,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                         return DistanceTypes.Miles;
                     case RateTimeTypes.NauticalMilesHour:
                     case RateTimeTypes.NauticalMilesSec:
-                        return DistanceTypes.NauticalMile;
+                        return DistanceTypes.NauticalMiles;
                     default:
                         return DistanceTypes.Meters;
                 }

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProLinesViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProLinesViewModel.cs
@@ -177,7 +177,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                 lu = LinearUnit.Meters;
             else if (distType == DistanceTypes.Miles)
                 lu = LinearUnit.Miles;
-            else if (distType == DistanceTypes.NauticalMile)
+            else if (distType == DistanceTypes.NauticalMiles)
                 lu = LinearUnit.NauticalMiles;
             else if (distType == DistanceTypes.Yards)
                 lu = LinearUnit.Yards;

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
@@ -74,6 +74,12 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                 System.Diagnostics.Debug.WriteLine("Probably Running from Unit Tests");
             }
 
+            ArcGIS.Desktop.Mapping.Events.ActiveMapViewChangedEvent.Subscribe((args) =>
+            {
+                // Subscribe to this event in case the ActiveMap already has layers with features (so buttons are enabled on load)
+                RaisePropertyChanged(() => HasMapGraphics);
+            });
+
             configObserver = new PropertyObserver<DistanceAndDirectionConfig>(DistanceAndDirectionConfig.AddInConfig)
             .RegisterHandler(n => n.DisplayCoordinateType, n =>
             {

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProTabBaseViewModel.cs
@@ -1004,7 +1004,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                 case DistanceTypes.Miles:
                     result = LinearUnit.Miles;
                     break;
-                case DistanceTypes.NauticalMile:
+                case DistanceTypes.NauticalMiles:
                     result = LinearUnit.NauticalMiles;
                     break;
                 case DistanceTypes.Yards:


### PR DESCRIPTION
#591 - Clear Button Redo

Addresses: 

1. Issue where Clear/SaveAs Button not enabled on Project load if feature class had existing features - see:https://github.com/Esri/distance-direction-addin-dotnet/issues/591#issuecomment-394788888
2. @topowright request to change "NauticalMile" to "NauticalMiles" in feature class distance units - looks like this now, but there is still a mismatch between label expression and attribute value (no space):

![image](https://user-images.githubusercontent.com/3090809/40996704-7751befa-68d0-11e8-84c6-97de5ec240e6.png)
