### PR TITLE
Remove radials attribute from Rings export

### DIFF
--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/Models/FeatureClassUtils.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/Models/FeatureClassUtils.cs
@@ -250,21 +250,18 @@ namespace ArcMapAddinDistanceAndDirection.Models
                                     
                                     System.Object rings;
                                     System.Object distance;
-                                    System.Object radials;
                                     System.Object distunit;
                                     System.Object centerx;
                                     System.Object centery;
 
                                     graphic.Attributes.TryGetValue("rings", out rings);
                                     graphic.Attributes.TryGetValue("distance", out distance);
-                                    graphic.Attributes.TryGetValue("radials", out radials);
                                     graphic.Attributes.TryGetValue("distanceunit", out distunit);
                                     graphic.Attributes.TryGetValue("centerx", out centerx);
                                     graphic.Attributes.TryGetValue("centery", out centery);
 
                                     feature.set_Value(feature.Fields.FindField("Rings"), rings);
                                     feature.set_Value(feature.Fields.FindField("Distance"), distance);
-                                    feature.set_Value(feature.Fields.FindField("Radials"), radials);
                                     feature.set_Value(feature.Fields.FindField("DistanceUnit"), distunit);
                                     feature.set_Value(feature.Fields.FindField("CenterX"), centerx);
                                     feature.set_Value(feature.Fields.FindField("CenterY"), centery);
@@ -560,13 +557,6 @@ namespace ArcMapAddinDistanceAndDirection.Models
 
                                 field = new FieldClass();
                                 fieldEdit = (IFieldEdit)field;
-                                fieldEdit.Name_2 = "Radials";
-                                fieldEdit.AliasName_2 = "Radials";
-                                fieldEdit.Type_2 = esriFieldType.esriFieldTypeInteger;
-                                fieldsEdit.AddField(field);
-
-                                field = new FieldClass();
-                                fieldEdit = (IFieldEdit)field;
                                 fieldEdit.Name_2 = "CenterX";
                                 fieldEdit.AliasName_2 = "Center X";
                                 fieldEdit.Type_2 = esriFieldType.esriFieldTypeDouble;
@@ -679,21 +669,18 @@ namespace ArcMapAddinDistanceAndDirection.Models
                                 {
                                     System.Object rings;
                                     System.Object distance;
-                                    System.Object radials;
                                     System.Object distunit;
                                     System.Object centerx;
                                     System.Object centery;
 
                                     graphic.Attributes.TryGetValue("rings", out rings);
                                     graphic.Attributes.TryGetValue("distance", out distance);
-                                    graphic.Attributes.TryGetValue("radials", out radials);
                                     graphic.Attributes.TryGetValue("distanceunit", out distunit);
                                     graphic.Attributes.TryGetValue("centerx", out centerx);
                                     graphic.Attributes.TryGetValue("centery", out centery);
 
                                     feature.set_Value(feature.Fields.FindField("Rings"), rings);
                                     feature.set_Value(feature.Fields.FindField("Distance"), distance);
-                                    feature.set_Value(feature.Fields.FindField("Radials"), radials);
                                     feature.set_Value(feature.Fields.FindField("DistUnit"), distunit);
                                     feature.set_Value(feature.Fields.FindField("CenterX"), centerx);
                                     feature.set_Value(feature.Fields.FindField("CenterY"), centery);
@@ -958,12 +945,6 @@ namespace ArcMapAddinDistanceAndDirection.Models
                         pFldEdt.Name_2 = "DistanceUnit";
                         pFldEdt.AliasName_2 = "Distance Unit";
                         pFldEdt.Type_2 = esriFieldType.esriFieldTypeString;
-                        pFldsEdt.AddField(pFldEdt);
-
-                        pFldEdt = new FieldClass();
-                        pFldEdt.Name_2 = "Radials";
-                        pFldEdt.AliasName_2 = "Radials";
-                        pFldEdt.Type_2 = esriFieldType.esriFieldTypeDouble;
                         pFldsEdt.AddField(pFldEdt);
 
                         pFldEdt = new FieldClass();

--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/RangeViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/RangeViewModel.cs
@@ -241,7 +241,6 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                     rrAttributes.Add("rings", NumberOfRings);
                     rrAttributes.Add("distance", radialLength);
                     rrAttributes.Add("distanceunit", lineDistanceType.ToString());
-                    rrAttributes.Add("radials", NumberOfRadials);
                     rrAttributes.Add("centerx", Point1.X);
                     rrAttributes.Add("centery", Point1.Y);
                     construct.ConstructGeodeticLineFromDistance(esriGeodeticType.esriGeodeticTypeLoxodrome, Point1, GetLinearUnit(), radialLength, azimuth, esriCurveDensifyMethod.esriCurveDensifyByDeviation, -1.0);
@@ -282,7 +281,6 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                     rrAttributes.Add("rings", NumberOfRings);
                     rrAttributes.Add("distance", radius);
                     rrAttributes.Add("distanceunit", lineDistanceType.ToString());
-                    rrAttributes.Add("radials", NumberOfRadials);
                     rrAttributes.Add("centerx", Point1.X);
                     rrAttributes.Add("centery", Point1.Y);
                     AddGraphicToMap((IGeometry)construct, color, attributes:rrAttributes);
@@ -433,7 +431,6 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 IDictionary<String, System.Object> rrAttributes = new Dictionary<String, System.Object>();
                 rrAttributes.Add("rings", NumberOfRings);
                 rrAttributes.Add("distance", Distance);
-                rrAttributes.Add("radials", NumberOfRadials);
                 rrAttributes.Add("centerx", Point1.X);
                 rrAttributes.Add("centery", Point1.Y);
                 rrAttributes.Add("distanceunit", lineDistanceType.ToString());
@@ -477,7 +474,6 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
                 IDictionary<String, System.Object> rrAttributes = new Dictionary<String, System.Object>();
                 rrAttributes.Add("rings", NumberOfRings);
                 rrAttributes.Add("distance", Distance);
-                rrAttributes.Add("radials", NumberOfRadials);
                 construct.ConstructGeodesicCircle(Point1, GetLinearUnit(), Distance, esriCurveDensifyMethod.esriCurveDensifyByAngle, 0.45);
                 Point2 = (construct as IPolyline).ToPoint;
                 var color = new RgbColorClass() as IColor;

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProGraphicAttributes.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProGraphicAttributes.cs
@@ -55,7 +55,6 @@ namespace ProAppDistanceAndDirectionModule
         public int numRings { get; set; }
         public double distance { get; set; }
         public String distanceunit { get; set; }
-        public int numRadials { get; set; }
         public Double centerx { get; set; }
         public Double centery { get; set; }
         public String ringorradial { get; set; }

--- a/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProRangeViewModel.cs
+++ b/source/addins/ProAppDistanceAndDirectionModule/ProAppDistanceAndDirectionModule/ViewModels/ProRangeViewModel.cs
@@ -207,7 +207,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                         // Hold onto the attributes in case user saves graphics to file later
                         RangeAttributes rangeAttributes = new RangeAttributes() {
                             mapPoint = Point1, numRings = NumberOfRings,
-                            distance = radialLength, numRadials = NumberOfRadials,
+                            distance = radialLength,
                             centerx = Point1.X, centery = Point1.Y,
                             distanceunit = LineDistanceType.ToString(), ringorradial = "Radial" };
 
@@ -263,7 +263,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
                     // Hold onto the attributes in case user saves graphics to file later
                     RangeAttributes rangeAttributes = new RangeAttributes() {
                         mapPoint = Point1, numRings = numberOfRings, distance = radius,
-                        numRadials = numberOfRadials, centerx = Point1.X, centery = Point1.Y,
+                        centerx = Point1.X, centery = Point1.Y,
                         distanceunit = LineDistanceType.ToString(), ringorradial = "Ring" };
 
                     CreateRangeRingOrRadialFeature(geom, rangeAttributes);
@@ -401,7 +401,7 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             // Hold onto the attributes in case user saves graphics to file later
             RangeAttributes rangeAttributes = new RangeAttributes() {
                 mapPoint = Point1, numRings = NumberOfRings,
-                distance = Distance, numRadials = NumberOfRadials,
+                distance = Distance,
                 centerx = Point1.X, centery = Point1.Y,
                 distanceunit = LineDistanceType.ToString(), ringorradial = "Ring" };
 
@@ -427,7 +427,10 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
             ClearTempGraphics();
 
             // Hold onto the attributes in case user saves graphics to file later
-            RangeAttributes rangeAttributes = new RangeAttributes() { mapPoint = Point1, numRings = NumberOfRings, distance = Distance, numRadials = NumberOfRadials, centerx = Point1.X, centery = Point1.Y, distanceunit = LineDistanceType.ToString() };
+            RangeAttributes rangeAttributes = new RangeAttributes() { mapPoint = Point1,
+                numRings = NumberOfRings, distance = Distance,
+                centerx = Point1.X, centery = Point1.Y,
+                distanceunit = LineDistanceType.ToString() };
 
             AddGraphicToMap(Point1, ColorFactory.Instance.GreenRGB, null, true, 5.0);
             AddGraphicToMap(geom, ColorFactory.Instance.GreyRGB, rangeAttributes, true);
@@ -488,9 +491,6 @@ namespace ProAppDistanceAndDirectionModule.ViewModels
 
                     if (ringDefinition.FindField("Rings") >= 0)
                         rowBuffer["Rings"] = attributes.numRings;        // Double
-
-                    if (ringDefinition.FindField("Radials") >= 0)
-                        rowBuffer["Radials"] = attributes.numRadials;    // Text
 
                     if (ringDefinition.FindField("CenterX") >= 0)
                         rowBuffer["CenterX"] = attributes.centerx;       // Double


### PR DESCRIPTION
An action item from today's sprint review to complete #544 + #560

@topowright @lfunkhouser @dfoll @ACueva @kgonzago @BobBooth 

IMPORTANT: this attribute will also need to be removed from the layer package (lpkx) this is why this column still appears in Pro (with Nulls below)

Export attribute should look like this after PR:

Pro:
![image](https://user-images.githubusercontent.com/3090809/41005379-32785e18-68eb-11e8-9caf-5a10b12c7282.png)

ArcMap:
![image](https://user-images.githubusercontent.com/3090809/41005433-67956708-68eb-11e8-86dc-5a18b069b6af.png)

 
