### PR TITLE
Revert "Set OverwriteOutput in case kmz already exists"

### DIFF
--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/Models/KMLUtils.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/Models/KMLUtils.cs
@@ -34,8 +34,6 @@ namespace ArcMapAddinDistanceAndDirection.Models
                 string kmzName = System.IO.Path.GetFileName(kmzOutputPath);
 
                 IGeoProcessor2 gp = new GeoProcessorClass();
-                gp.OverwriteOutput = true;
-
                 IVariantArray parameters = new VarArrayClass();
                 parameters.Add(tmpShapefilePath);
                 parameters.Add(kmzName);


### PR DESCRIPTION
Reverts Esri/distance-direction-addin-dotnet#600 This PR is causing ArcMap to crash: 

start up arcmap
create graphic from dd
export graphic as a kmz
open in earth
close earth
close armap
reopen arcmap

result is arcmap normal mxt is curropted and does not open back up. 

Symbology is not correct in ArcGIS Earth as well