### PR TITLE
Spatial Ref check before adding text graphic

### DIFF
--- a/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
+++ b/source/addins/ArcMapAddinDistanceAndDirection/ArcMapAddinDistanceAndDirection/ViewModels/LinesViewModel.cs
@@ -313,6 +313,8 @@ namespace ArcMapAddinDistanceAndDirection.ViewModels
 
                 if (HasPoint1 && HasPoint2)
                 {
+                    if (Point1.SpatialReference != ArcMap.Document.FocusMap.SpatialReference)
+                        Point1.Project(ArcMap.Document.FocusMap.SpatialReference);
                     //Get line distance type
                     DistanceTypes dtVal = (DistanceTypes)LineDistanceType;
                     //Get azimuth type


### PR DESCRIPTION
Addresses #607. Start point is used as the anchor for text graphics. A check for spatial reference was implemented before any text graphic is created on the map. 